### PR TITLE
CMS5: Use json_encode instead of Convert::raw2json

### DIFF
--- a/src/controllers/PartialUserFormController.php
+++ b/src/controllers/PartialUserFormController.php
@@ -211,7 +211,7 @@ class PartialUserFormController extends UserDefinedFormController
                 $linkTag,
                 Convert::raw2att($file->AbsoluteLink()),
                 Convert::raw2att($file->Name),
-                Convert::raw2json($fileAttributes)
+                json_encode($fileAttributes)
             );
             $inputField = $fields->dataFieldByName($upload->Name);
             if ($inputField) {


### PR DESCRIPTION
### Convert::raw2json is removed use json_encode

Reference: https://docs.silverstripe.org/en/5/changelogs/5.0.0/#silverstripe-framework