### PR TITLE
Bugfix/MPW 735 file upload

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -16,3 +16,7 @@ SilverStripe\UserForms\Model\Submission\SubmittedFileField:
 SilverStripe\UserForms\Model\EditableFormField\EditableFileField:
   extensions:
     - Firesphere\PartialUserforms\Extensions\EditableFileFieldExtension
+
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\UserForms\Form\UserFormsRequiredFields:
+    class: Firesphere\PartialUserforms\Extensions\UserFormsRequiredFieldsExtension

--- a/client/src/js/repeatfield.js
+++ b/client/src/js/repeatfield.js
@@ -31,7 +31,7 @@ const hideRepeatGroup = (event) => {
       // If repeated fields has values show alert message
       let hasValues = false;
       const elements = buttonContainer.querySelectorAll('input, select, textarea');
-      for (count = 0; count < elements.length; count++) {
+      for (let count = 0; count < elements.length; count++) {
         const currentElement = elements[count];
         if (currentElement.getAttribute('type') == 'hidden') {
           continue;

--- a/src/controllers/PartialUserFormController.php
+++ b/src/controllers/PartialUserFormController.php
@@ -92,14 +92,14 @@ class PartialUserFormController extends UserDefinedFormController
 
         // Copied from {@link UserDefinedFormController}
         if ($controller->Content && $form && !$controller->config()->disable_form_content_shortcode) {
-            $hasLocation = stristr($controller->Content, '$UserDefinedForm');
+            $hasLocation = stristr($controller->Content ?? '', '$UserDefinedForm');
             if ($hasLocation) {
                 /** @see Requirements_Backend::escapeReplacement */
-                $formEscapedForRegex = addcslashes($form->forTemplate(), '\\$');
+                $formEscapedForRegex = addcslashes($form->forTemplate() ?? '', '\\$');
                 $content = preg_replace(
                     '/(<p[^>]*>)?\\$UserDefinedForm(<\\/p>)?/i',
-                    $formEscapedForRegex,
-                    $controller->Content
+                    $formEscapedForRegex ?? '',
+                    $controller->Content ?? ''
                 );
 
                 return $controller->customise([
@@ -167,6 +167,7 @@ class PartialUserFormController extends UserDefinedFormController
             if ($inputField) {
                 $inputField->setRightTitle(DBField::create_field('HTMLText', $fileLink))
                     ->removeExtraClass('requiredField')
+                    ->setAttribute('required', false)
                     ->setAttribute('data-rule-required', 'false')
                     ->setAttribute('aria-required', 'false');
             }

--- a/src/extensions/UserFormsRequiredFieldsExtension.php
+++ b/src/extensions/UserFormsRequiredFieldsExtension.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Firesphere\PartialUserforms\Extensions;
+
+use InvalidArgumentException;
+use SilverStripe\Forms\FormField;
+use SilverStripe\UserForms\Model\EditableFormField;
+use SilverStripe\UserForms\Form\UserFormsRequiredFields;
+
+/**
+ * This is exact copy of vendor/silverstripe/userforms/code/Form/UserFormsRequiredFields.php
+ * What's changed:
+ * https://github.com/silverstripe/silverstripe-userforms/blob/6.2.6/code/Form/UserFormsRequiredFields.php#L113-L117
+ * the above lines are replace by following single line code
+ * $error = (count($value ?? [])) ? false : true;
+ *
+ * This change has been added to fix the bug https://mbiessd.atlassian.net/browse/MWP-735
+ * or as described in https://github.com/silverstripeltd/silverstripe-partial-userforms/pull/8
+ */
+class UserFormsRequiredFieldsExtension extends UserFormsRequiredFields
+{
+    /**
+     * Allows validation of fields via specification of a php function for
+     * validation which is executed after the form is submitted.
+     *
+     * @param array $data
+     *
+     * @return bool
+     */
+    public function php($data)
+    {
+        $valid = true;
+        $fields = $this->form->Fields();
+
+        foreach ($fields as $field) {
+            $valid = ($field->validate($this) && $valid);
+        }
+
+        if (empty($this->required)) {
+            return $valid;
+        }
+
+        foreach ($this->required as $fieldName) {
+            if (!$fieldName) {
+                continue;
+            }
+
+            // get form field
+            if ($fieldName instanceof FormField) {
+                $formField = $fieldName;
+                $fieldName = $fieldName->getName();
+            } else {
+                $formField = $fields->dataFieldByName($fieldName);
+            }
+
+            // get editable form field - owns display rules for field
+            $editableFormField = $this->getEditableFormFieldByName($fieldName);
+
+            // Validate if the field is displayed
+            $error =
+                $editableFormField->isDisplayed($data) &&
+                $this->validateRequired($formField, $data);
+
+            // handle error case
+            if ($formField && $error) {
+                $this->handleError($formField, $fieldName);
+                $valid = false;
+            }
+        }
+
+        return $valid;
+    }
+
+    /**
+     * Retrieve an Editable Form field by its name.
+     * @param string $name
+     * @return EditableFormField
+     */
+    private function getEditableFormFieldByName($name)
+    {
+        $field = EditableFormField::get()->filter(['Name' => $name])->first();
+
+        if ($field) {
+            return $field;
+        }
+
+        // This should happen if form field data got corrupted
+        throw new InvalidArgumentException(sprintf(
+            'Could not find EditableFormField with name `%s`',
+            $name
+        ));
+    }
+
+    /**
+     * Check if the validation rules for the specified field are met by the provided data.
+     *
+     * @note Logic replicated from php() method of parent class `SilverStripe\Forms\RequiredFields`
+     * @param EditableFormField $field
+     * @param array $data
+     * @return bool
+     */
+    private function validateRequired(FormField $field, array $data)
+    {
+        $error = false;
+        $fieldName = $field->getName();
+        // submitted data for file upload fields come back as an array
+        $value = isset($data[$fieldName]) ? $data[$fieldName] : null;
+
+        if (is_array($value)) {
+            $error = (count($value ?? [])) ? false : true;
+        } else {
+            // assume a string or integer
+            $error = (strlen($value ?? '')) ? false : true;
+        }
+
+        return $error;
+    }
+
+    /**
+     * Register an error for the provided field.
+     * @param FormField $formField
+     * @param string $fieldName
+     * @return void
+     */
+    private function handleError(FormField $formField, $fieldName)
+    {
+        $errorMessage = _t(
+            'SilverStripe\\Forms\\Form.FIELDISREQUIRED',
+            '{name} is required',
+            [
+                'name' => strip_tags(
+                    '"' . ($formField->Title() ? $formField->Title() : $fieldName) . '"'
+                )
+            ]
+        );
+
+        if ($msg = $formField->getCustomValidationMessage()) {
+            $errorMessage = $msg;
+        }
+
+        $this->validationError($fieldName, $errorMessage, "required");
+    }
+}


### PR DESCRIPTION
Bug: User can't submit Space Form if 'Saved and exit' after document upload

Steps to replicate:
- Create a new user form with partial submission enabled 
- Add file upload field 
- Make this file upload field required
- Goto form page
- Upload a file
- Save the form and logout
- Open the form page in new incognito window
- View the form page
- It shows file is uploaded
- Submit the form
- Form page submits and reloads with validation error that file is not uploaded

Error:
https://github.com/silverstripe/silverstripe-userforms/blob/f2cda50320ec5b081b111f3e902b5bfc9e0b1f95/code/Form/UserFormsRequiredFields.php#L113-L117 `validateRequried` is checking if the file is uploaded, whereas in case of Space form file is uploaded via another user and does not exists in current session hence it interprets that the file is not there and set error code which fails the validation.