### PR TITLE
add return type for setup() functions to match parent class

### DIFF
--- a/tests/unit/PartialFieldSubmissionTest.php
+++ b/tests/unit/PartialFieldSubmissionTest.php
@@ -64,7 +64,7 @@ class PartialFieldSubmissionTest extends SapphireTest
         $this->assertTrue($this->field->canDelete($member));
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/PartialFileFieldSubmissionTest.php
+++ b/tests/unit/PartialFileFieldSubmissionTest.php
@@ -61,7 +61,7 @@ class PartialFileFieldSubmissionTest extends SapphireTest
         $this->assertTrue($this->field->canDelete($member));
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $udf = UserDefinedForm::create(['Title' => 'Test']);

--- a/tests/unit/PartialFormSubmissionTest.php
+++ b/tests/unit/PartialFormSubmissionTest.php
@@ -152,7 +152,7 @@ class PartialFormSubmissionTest extends SapphireTest
         $this->assertEquals($pwd, $this->submission->Password);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/PartialSubmissionJobTest.php
+++ b/tests/unit/PartialSubmissionJobTest.php
@@ -179,7 +179,7 @@ class PartialSubmissionJobTest extends SapphireTest
         $this->assertEmailSent('test@example.com', 'site@' . Director::host());
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/PartialSubmissionTaskTest.php
+++ b/tests/unit/PartialSubmissionTaskTest.php
@@ -68,7 +68,7 @@ class PartialSubmissionTaskTest extends SapphireTest
         $this->assertEmailSent('usernoconfig@example.com');
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Config::modify()->set(QueuedJobService::class, 'use_shutdown_function', false);

--- a/tests/unit/SiteConfigExtensionTest.php
+++ b/tests/unit/SiteConfigExtensionTest.php
@@ -111,7 +111,7 @@ class SiteConfigExtensionTest extends SapphireTest
         $this->assertCount(1, $jobs);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Parent class had it's return types set in 2022